### PR TITLE
Emoji Checkbox Component - Issue #8

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -44,6 +44,15 @@ export namespace Components {
      */
     variant: 'circular' | 'rounded' | 'square';
   }
+  interface CheckmarkComponent {
+    checkFalse: string;
+    checkTrue: string;
+    checked: boolean;
+  }
+  interface EmojiCheckboxComponent {
+    checked: boolean;
+    name: string;
+  }
   interface GoogleTagManager {
     /**
      * The google tag manage container ID
@@ -54,6 +63,9 @@ export namespace Components {
     srcImg: string;
     srcImgName: string;
     srcNextGen: string;
+  }
+  interface LabelComponent {
+    checked: boolean;
   }
   interface ModalWindow {
     cancelText: string;
@@ -124,6 +136,16 @@ declare global {
     prototype: HTMLAvatarComponentElement;
     new (): HTMLAvatarComponentElement;
   };
+  interface HTMLCheckmarkComponentElement extends Components.CheckmarkComponent, HTMLStencilElement {}
+  var HTMLCheckmarkComponentElement: {
+    prototype: HTMLCheckmarkComponentElement;
+    new (): HTMLCheckmarkComponentElement;
+  };
+  interface HTMLEmojiCheckboxComponentElement extends Components.EmojiCheckboxComponent, HTMLStencilElement {}
+  var HTMLEmojiCheckboxComponentElement: {
+    prototype: HTMLEmojiCheckboxComponentElement;
+    new (): HTMLEmojiCheckboxComponentElement;
+  };
   interface HTMLGoogleTagManagerElement extends Components.GoogleTagManager, HTMLStencilElement {}
   var HTMLGoogleTagManagerElement: {
     prototype: HTMLGoogleTagManagerElement;
@@ -133,6 +155,11 @@ declare global {
   var HTMLImageComponentElement: {
     prototype: HTMLImageComponentElement;
     new (): HTMLImageComponentElement;
+  };
+  interface HTMLLabelComponentElement extends Components.LabelComponent, HTMLStencilElement {}
+  var HTMLLabelComponentElement: {
+    prototype: HTMLLabelComponentElement;
+    new (): HTMLLabelComponentElement;
   };
   interface HTMLModalWindowElement extends Components.ModalWindow, HTMLStencilElement {}
   var HTMLModalWindowElement: {
@@ -161,8 +188,11 @@ declare global {
   };
   interface HTMLElementTagNameMap {
     'avatar-component': HTMLAvatarComponentElement;
+    'checkmark-component': HTMLCheckmarkComponentElement;
+    'emoji-checkbox-component': HTMLEmojiCheckboxComponentElement;
     'google-tag-manager': HTMLGoogleTagManagerElement;
     'image-component': HTMLImageComponentElement;
+    'label-component': HTMLLabelComponentElement;
     'modal-window': HTMLModalWindowElement;
     'my-button': HTMLMyButtonElement;
     'my-component': HTMLMyComponentElement;
@@ -209,6 +239,16 @@ declare namespace LocalJSX {
      */
     variant?: 'circular' | 'rounded' | 'square';
   }
+  interface CheckmarkComponent {
+    checkFalse?: string;
+    checkTrue?: string;
+    checked?: boolean;
+  }
+  interface EmojiCheckboxComponent {
+    checked?: boolean;
+    name?: string;
+    onOnChange?: (event: CustomEvent<{ value: boolean; name: string }>) => void;
+  }
   interface GoogleTagManager {
     /**
      * The google tag manage container ID
@@ -219,6 +259,9 @@ declare namespace LocalJSX {
     srcImg?: string;
     srcImgName?: string;
     srcNextGen?: string;
+  }
+  interface LabelComponent {
+    checked?: boolean;
   }
   interface ModalWindow {
     cancelText?: string;
@@ -284,8 +327,11 @@ declare namespace LocalJSX {
   }
   interface IntrinsicElements {
     'avatar-component': AvatarComponent;
+    'checkmark-component': CheckmarkComponent;
+    'emoji-checkbox-component': EmojiCheckboxComponent;
     'google-tag-manager': GoogleTagManager;
     'image-component': ImageComponent;
+    'label-component': LabelComponent;
     'modal-window': ModalWindow;
     'my-button': MyButton;
     'my-component': MyComponent;
@@ -298,8 +344,11 @@ declare module '@stencil/core' {
   export namespace JSX {
     interface IntrinsicElements {
       'avatar-component': LocalJSX.AvatarComponent & JSXBase.HTMLAttributes<HTMLAvatarComponentElement>;
+      'checkmark-component': LocalJSX.CheckmarkComponent & JSXBase.HTMLAttributes<HTMLCheckmarkComponentElement>;
+      'emoji-checkbox-component': LocalJSX.EmojiCheckboxComponent & JSXBase.HTMLAttributes<HTMLEmojiCheckboxComponentElement>;
       'google-tag-manager': LocalJSX.GoogleTagManager & JSXBase.HTMLAttributes<HTMLGoogleTagManagerElement>;
       'image-component': LocalJSX.ImageComponent & JSXBase.HTMLAttributes<HTMLImageComponentElement>;
+      'label-component': LocalJSX.LabelComponent & JSXBase.HTMLAttributes<HTMLLabelComponentElement>;
       'modal-window': LocalJSX.ModalWindow & JSXBase.HTMLAttributes<HTMLModalWindowElement>;
       'my-button': LocalJSX.MyButton & JSXBase.HTMLAttributes<HTMLMyButtonElement>;
       'my-component': LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -247,7 +247,6 @@ declare namespace LocalJSX {
   interface EmojiCheckboxComponent {
     checked?: boolean;
     name?: string;
-    onOnChange?: (event: CustomEvent<{ value: boolean; name: string }>) => void;
   }
   interface GoogleTagManager {
     /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -45,12 +45,27 @@ export namespace Components {
     variant: 'circular' | 'rounded' | 'square';
   }
   interface CheckmarkComponent {
+    /**
+     * Un-checked state emoji code
+     */
     checkFalse: string;
+    /**
+     * Checked state emoji code
+     */
     checkTrue: string;
+    /**
+     * Checkbox state
+     */
     checked: boolean;
   }
   interface EmojiCheckboxComponent {
+    /**
+     * The initial state of checkbox
+     */
     checked: boolean;
+    /**
+     * Checkbox name
+     */
     name: string;
   }
   interface GoogleTagManager {
@@ -65,6 +80,9 @@ export namespace Components {
     srcNextGen: string;
   }
   interface LabelComponent {
+    /**
+     * Checkbox state
+     */
     checked: boolean;
   }
   interface ModalWindow {
@@ -240,12 +258,27 @@ declare namespace LocalJSX {
     variant?: 'circular' | 'rounded' | 'square';
   }
   interface CheckmarkComponent {
+    /**
+     * Un-checked state emoji code
+     */
     checkFalse?: string;
+    /**
+     * Checked state emoji code
+     */
     checkTrue?: string;
+    /**
+     * Checkbox state
+     */
     checked?: boolean;
   }
   interface EmojiCheckboxComponent {
+    /**
+     * The initial state of checkbox
+     */
     checked?: boolean;
+    /**
+     * Checkbox name
+     */
     name?: string;
   }
   interface GoogleTagManager {
@@ -260,6 +293,9 @@ declare namespace LocalJSX {
     srcNextGen?: string;
   }
   interface LabelComponent {
+    /**
+     * Checkbox state
+     */
     checked?: boolean;
   }
   interface ModalWindow {

--- a/src/components/emoji-checkbox-component/checkmark-component/checkmark-component.css
+++ b/src/components/emoji-checkbox-component/checkmark-component/checkmark-component.css
@@ -1,0 +1,20 @@
+:host {
+  --checkFalse: '';
+  --checkTrue: '';
+  display: inline-block;
+}
+
+span.check-true::after,
+span.check-false::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+span.check-true::after {
+  content: var(--checkTrue);
+}
+
+span.check-false::after {
+  content: var(--checkFalse);
+}

--- a/src/components/emoji-checkbox-component/checkmark-component/checkmark-component.css
+++ b/src/components/emoji-checkbox-component/checkmark-component/checkmark-component.css
@@ -4,13 +4,6 @@
   display: inline-block;
 }
 
-span.check-true::after,
-span.check-false::after {
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-
 span.check-true::after {
   content: var(--checkTrue);
 }

--- a/src/components/emoji-checkbox-component/checkmark-component/checkmark-component.tsx
+++ b/src/components/emoji-checkbox-component/checkmark-component/checkmark-component.tsx
@@ -6,12 +6,25 @@ import { Component, Host, h, Prop, Element } from '@stencil/core';
   shadow: true,
 })
 export class CheckmarkComponent {
+  /**
+   * Checked state emoji code
+   */
   @Prop() checkTrue: string;
+  /**
+   * Un-checked state emoji code
+   */
   @Prop() checkFalse: string;
+  /**
+   * Checkbox state
+   */
   @Prop() checked: boolean = false;
+  /**
+   * Root element
+   */
   @Element() el: HTMLElement;
 
   componentDidLoad() {
+    // set emoji codes as css custom properties
     this.el.style.setProperty('--checkTrue', `"${this.checkTrue}"`);
     this.el.style.setProperty('--checkFalse', `"${this.checkFalse}"`);
   }

--- a/src/components/emoji-checkbox-component/checkmark-component/checkmark-component.tsx
+++ b/src/components/emoji-checkbox-component/checkmark-component/checkmark-component.tsx
@@ -1,0 +1,26 @@
+import { Component, Host, h, Prop, Element } from '@stencil/core';
+
+@Component({
+  tag: 'checkmark-component',
+  styleUrl: 'checkmark-component.css',
+  shadow: true,
+})
+export class CheckmarkComponent {
+  @Prop() checkTrue: string;
+  @Prop() checkFalse: string;
+  @Prop() checked: boolean = false;
+  @Element() el: HTMLElement;
+
+  componentDidLoad() {
+    this.el.style.setProperty('--checkTrue', `"${this.checkTrue}"`);
+    this.el.style.setProperty('--checkFalse', `"${this.checkFalse}"`);
+  }
+
+  render() {
+    return (
+      <Host>
+        <span class={this.checked ? 'check-true' : 'check-false'} />
+      </Host>
+    );
+  }
+}

--- a/src/components/emoji-checkbox-component/checkmark-component/test/checkmark-component.spec.tsx
+++ b/src/components/emoji-checkbox-component/checkmark-component/test/checkmark-component.spec.tsx
@@ -1,0 +1,24 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { CheckmarkComponent } from '../checkmark-component';
+
+describe('checkmark-component', () => {
+  let page: SpecPage;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [CheckmarkComponent],
+      html: `
+        <checkmark-component></checkmark-component>
+      `,
+    });
+  });
+  it('renders', async () => {
+    expect(page.root).toEqualHtml(`
+      <checkmark-component>
+        <mock:shadow-root>
+          <slot></slot>
+          <span class="check-false"></span>
+        </mock:shadow-root>
+      </checkmark-component>
+    `);
+  });
+});

--- a/src/components/emoji-checkbox-component/emoji-checkbox-component.css
+++ b/src/components/emoji-checkbox-component/emoji-checkbox-component.css
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  position: relative;
+}

--- a/src/components/emoji-checkbox-component/emoji-checkbox-component.tsx
+++ b/src/components/emoji-checkbox-component/emoji-checkbox-component.tsx
@@ -6,16 +6,41 @@ import { Component, Host, h, Prop, Element } from '@stencil/core';
   shadow: true,
 })
 export class EmojiCheckboxComponent {
+  /**
+   * The initial state of checkbox
+   */
   @Prop({ mutable: true }) checked: boolean = false;
+  /**
+   * Checkbox name
+   */
   @Prop() name: string;
+  /**
+   * Root element
+   */
   @Element() el: HTMLElement;
 
-  handleClick = () => {
-    this.checked = !this.checked;
+  /**
+   * Pass state to child components
+   */
+  passStateToChildren() {
     this.el.childNodes.forEach(element => {
       element['checked'] = this.checked;
     });
+  }
+
+  /**
+   * Toggle the checkbox,
+   * and pass the new state to child components
+   */
+  handleClick = () => {
+    this.checked = !this.checked;
+    this.passStateToChildren();
   };
+
+  componentWillLoad() {
+    // pass state to children on mount
+    this.passStateToChildren();
+  }
 
   render() {
     return (

--- a/src/components/emoji-checkbox-component/emoji-checkbox-component.tsx
+++ b/src/components/emoji-checkbox-component/emoji-checkbox-component.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Event, EventEmitter, Element } from '@stencil/core';
+import { Component, Host, h, Prop, Element } from '@stencil/core';
 
 @Component({
   tag: 'emoji-checkbox-component',
@@ -8,15 +8,10 @@ import { Component, Host, h, Prop, Event, EventEmitter, Element } from '@stencil
 export class EmojiCheckboxComponent {
   @Prop({ mutable: true }) checked: boolean = false;
   @Prop() name: string;
-  @Event() onChange: EventEmitter<{ value: boolean; name: string }>;
   @Element() el: HTMLElement;
 
   handleClick = () => {
     this.checked = !this.checked;
-    this.onChange.emit({
-      name: this.name,
-      value: this.checked,
-    });
     this.el.childNodes.forEach(element => {
       element['checked'] = this.checked;
     });

--- a/src/components/emoji-checkbox-component/emoji-checkbox-component.tsx
+++ b/src/components/emoji-checkbox-component/emoji-checkbox-component.tsx
@@ -1,0 +1,32 @@
+import { Component, Host, h, Prop, Event, EventEmitter, Element } from '@stencil/core';
+
+@Component({
+  tag: 'emoji-checkbox-component',
+  styleUrl: 'emoji-checkbox-component.css',
+  shadow: true,
+})
+export class EmojiCheckboxComponent {
+  @Prop({ mutable: true }) checked: boolean = false;
+  @Prop() name: string;
+  @Event() onChange: EventEmitter<{ value: boolean; name: string }>;
+  @Element() el: HTMLElement;
+
+  handleClick = () => {
+    this.checked = !this.checked;
+    this.onChange.emit({
+      name: this.name,
+      value: this.checked,
+    });
+    this.el.childNodes.forEach(element => {
+      element['checked'] = this.checked;
+    });
+  };
+
+  render() {
+    return (
+      <Host onClick={this.handleClick}>
+        <slot />
+      </Host>
+    );
+  }
+}

--- a/src/components/emoji-checkbox-component/label-component/label-component.css
+++ b/src/components/emoji-checkbox-component/label-component/label-component.css
@@ -1,4 +1,3 @@
 :host {
   display: inline-block;
-  margin-left: 1.5rem;
 }

--- a/src/components/emoji-checkbox-component/label-component/label-component.css
+++ b/src/components/emoji-checkbox-component/label-component/label-component.css
@@ -1,0 +1,4 @@
+:host {
+  display: inline-block;
+  margin-left: 1.5rem;
+}

--- a/src/components/emoji-checkbox-component/label-component/label-component.tsx
+++ b/src/components/emoji-checkbox-component/label-component/label-component.tsx
@@ -1,0 +1,20 @@
+import { Component, Host, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'label-component',
+  styleUrl: 'label-component.css',
+  shadow: true,
+})
+export class LabelComponent {
+  @Prop() checked: boolean = false;
+
+  render() {
+    return (
+      <Host>
+        <label>
+          <slot />
+        </label>
+      </Host>
+    );
+  }
+}

--- a/src/components/emoji-checkbox-component/label-component/label-component.tsx
+++ b/src/components/emoji-checkbox-component/label-component/label-component.tsx
@@ -6,6 +6,9 @@ import { Component, Host, h, Prop } from '@stencil/core';
   shadow: true,
 })
 export class LabelComponent {
+  /**
+   * Checkbox state
+   */
   @Prop() checked: boolean = false;
 
   render() {

--- a/src/components/emoji-checkbox-component/label-component/test/label-component.spec.tsx
+++ b/src/components/emoji-checkbox-component/label-component/test/label-component.spec.tsx
@@ -1,0 +1,21 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { LabelComponent } from '../label-component';
+
+describe('label-component', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [LabelComponent],
+      html: `<label-component>Hello World!</label-component>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <label-component>
+        <mock:shadow-root>
+          <label>
+            <slot></slot>
+          </label>
+        </mock:shadow-root>
+        Hello World!
+      </label-component>
+    `);
+  });
+});

--- a/src/components/emoji-checkbox-component/test/emoji-checkbox-component.e2e.ts
+++ b/src/components/emoji-checkbox-component/test/emoji-checkbox-component.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('emoji-checkbox-component', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<emoji-checkbox-component></emoji-checkbox-component>');
+
+    const element = await page.find('emoji-checkbox-component');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/emoji-checkbox-component/test/emoji-checkbox-component.spec.tsx
+++ b/src/components/emoji-checkbox-component/test/emoji-checkbox-component.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { EmojiCheckboxComponent } from '../emoji-checkbox-component';
+
+describe('emoji-checkbox-component', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [EmojiCheckboxComponent],
+      html: `<emoji-checkbox-component></emoji-checkbox-component>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <emoji-checkbox-component>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </emoji-checkbox-component>
+    `);
+  });
+});

--- a/src/components/emoji-checkbox-component/test/emoji-checkbox-component.spec.tsx
+++ b/src/components/emoji-checkbox-component/test/emoji-checkbox-component.spec.tsx
@@ -1,18 +1,13 @@
-import { newSpecPage } from '@stencil/core/testing';
 import { EmojiCheckboxComponent } from '../emoji-checkbox-component';
 
 describe('emoji-checkbox-component', () => {
-  it('renders', async () => {
-    const page = await newSpecPage({
-      components: [EmojiCheckboxComponent],
-      html: `<emoji-checkbox-component></emoji-checkbox-component>`,
-    });
-    expect(page.root).toEqualHtml(`
-      <emoji-checkbox-component>
-        <mock:shadow-root>
-          <slot></slot>
-        </mock:shadow-root>
-      </emoji-checkbox-component>
-    `);
+  it('should toggle the checked property', () => {
+    const toggle = new EmojiCheckboxComponent();
+
+    expect(toggle.checked).toBe(false);
+
+    toggle.handleClick();
+
+    expect(toggle.checked).toBe(true);
   });
 });

--- a/src/index.html
+++ b/src/index.html
@@ -36,6 +36,12 @@
         <my-input placeholder="Input North American phone number" pattern="^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$" size="large"> </my-input>
         <my-input placeholder="Input International phone number" pattern="^\+(?:[0-9] ?){6,14}[0-9]$" size="large"> </my-input>
       </section>
+      <section style="padding: 30px">
+        <emoji-checkbox-component id="test" name="test" checked="false">
+          <checkmark-component check-true="\1F315" check-false="\1F311"></checkmark-component>
+          <label-component>Hello World!</label-component>
+        </emoji-checkbox-component>
+      </section>
     </main>
   </body>
 </html>


### PR DESCRIPTION
Hey,
This is an initial implementation to get your feedback.
Few things to note:
- I still want to add a utility that takes in all the props the user might use and pass them to the component.
- __I didn't use an actual `<input />` tag for this!__ The way I see it, an HTML `input` will just complicate things. Let me know what you think.
- Some thought is still needed regarding how and where this is going to be used. For example, I don't think this will play well when submitting a form via HTML (an actual `input` tag won't help as far as I could check...). Right now an event listener on the `click` event will receive only `e.target.name` and `e.target.checked`.
